### PR TITLE
Remove unused inspect.isasyncgen reference

### DIFF
--- a/graphql_ws/aiohttp.py
+++ b/graphql_ws/aiohttp.py
@@ -1,4 +1,4 @@
-from inspect import isawaitable, isasyncgen
+from inspect import isawaitable
 from asyncio import ensure_future, wait, shield
 
 from aiohttp import WSMsgType


### PR DESCRIPTION
Allow use in Python 3.5.x by removing unused `inspect.isasyncgen` reference.